### PR TITLE
Update calendar owner options page

### DIFF
--- a/nolte/views/calendar_owner_view.xml
+++ b/nolte/views/calendar_owner_view.xml
@@ -6,29 +6,12 @@
             <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
             <field name="arch" type="xml">
 
-                <!-- Überprüfen, ob page[4] existiert -->
-                <xpath expr="//page[position()=4]" position="replace">
-                    <page string="Page 4">
-                        <group>
-                            <field name="name"/>
-                        </group>
-                    </page>
-                </xpath>
-
-                <!-- Überprüfen, ob page[3] existiert -->
-                <xpath expr="//page[position()=3]" position="replace">
-                    <page string="Page 3">
-                        <group>
-                            <field name="name"/>
-                        </group>
-                    </page>
-                </xpath>
-
-                <!-- Erweiterung der Ansicht -->
-                <xpath expr="//field[@name='location']" position="after">
-                    <label for="user_id" string="Mitarbeiter"/>
-                    <field name="user_id" nolabel="1" can_create="true" can_write="true"
-                           modifiers="{'readonly': [['state', 'in', ['done']]]}"/>
+                <xpath expr="//page[@name='options']" position="inside">
+                    <group string="Mitarbeiter">
+                        <label for="user_id" string="Mitarbeiter"/>
+                        <field name="user_id" nolabel="1" can_create="true" can_write="true"
+                               modifiers="{'readonly': [['state', 'in', ['done']]]}"/>
+                    </group>
                 </xpath>
 
             </field>


### PR DESCRIPTION
## Summary
- remove unused page replacements in calendar event form inheritance
- insert the Mitarbeiter field directly inside the options tab to manage the event owner

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b43d0c5fc832092fd51faf5e7dc67)