### PR TITLE
[19.0] nolte_overtime_billing: migrate module metadata to Odoo 19

### DIFF
--- a/nolte_overtime_billing/__manifest__.py
+++ b/nolte_overtime_billing/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "Nolte Overtime Billing (CSV → Sales Order)",
-    "version": "18.0.1.7.0",
+    "version": "19.0.1.0.0",
     "category": "Sales",
     "summary": "Import Stundenbericht-CSV, berechne Überstunden, erstelle Verkaufsauftrag (und daraus Rechnung).",
     "author": "Nolte Engineering / Nolte Sales",

--- a/nolte_overtime_billing/hooks.py
+++ b/nolte_overtime_billing/hooks.py
@@ -26,7 +26,7 @@ def pre_init_hook(cr):
 
 
 def post_init_hook(env):
-    """Post-init hook (Odoo 18): set default products if not configured yet."""
+    """Post-init hook (Odoo 19): set default products if not configured yet."""
     _ensure_product_template_base_unit_count_default_cr(env.cr)
 
     ICP = env["ir.config_parameter"].sudo()


### PR DESCRIPTION
### Motivation
- Prepare the `nolte_overtime_billing` module for Odoo 19 by updating its version metadata and documentation of hooks.

### Description
- Bumped the module manifest `version` from `18.0.1.7.0` to `19.0.1.0.0` in `nolte_overtime_billing/__manifest__.py`.
- Updated the `post_init_hook` docstring to reference Odoo 19 in `nolte_overtime_billing/hooks.py`.

### Testing
- Compiled the relevant Python files to validate syntax with `python -m py_compile nolte_overtime_billing/__manifest__.py nolte_overtime_billing/hooks.py nolte_overtime_billing/models/res_config_settings.py nolte_overtime_billing/models/nolte_overtime_settings.py nolte_overtime_billing/models/product_template.py nolte_overtime_billing/wizard/overtime_import_wizard.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fb811ac48320b9946d9d218b42fa)